### PR TITLE
Improve carousel image's resolution (also good for Retina-like displays)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,40 +1,53 @@
 Changelog
 =========
 
+1.6 (unreleased)
+----------------
+
+- Improved carousel images resolution (also good for Retina displays) [davilima6]
+
+
 1.5 August 20, 2015
---------------------
-     
+-------------------
+
 - Fixed resource registation and fixed js files for plone 5 [roman.ischiv]
 
+
 1.4 August 20, 2015
---------------------
-     
+-------------------
+
 - Initial release for Plone 5 [roman.ischiv]
 
+
 1.3.2 May 12, 2015
---------------------
-     
+------------------
+
 - Fixed script for contentCarousel [roman.ischiv]
+
 
 1.3.1 March 27, 2015
 --------------------
 
 - Fixed script for qgCarousel, added var 'gap' for item [roman.ischiv]
 
+
 1.3 March 18, 2015
--------------------
+------------------
 
 - Fixed script for qg carousel [roman.ischiv]
+
 
 1.2 January 29, 2015
 -------------------
 
 - Fixed templates for horizontal and vertical tabs [roman.ischiv]
 
+
 1.1 January 26, 2015
--------------------
+--------------------
 
 - Added qgCarousel and contentSlider template [roman.ischiv]
+
 
 1.0dev (unreleased)
 -------------------

--- a/quintagroup/slidertemplates/browser/templates/qgCarousel.pt
+++ b/quintagroup/slidertemplates/browser/templates/qgCarousel.pt
@@ -19,7 +19,7 @@
                tal:attributes="href item/getURL">
               <span tal:define="obj item/getObject;
                                 scales obj/@@images;
-                                thumbnail python: scales.scale('image', width=400, height=400);
+                                thumbnail python: scales.scale('image', scale='large');
                                 img thumbnail/url|nothing"
                     tal:condition="python:item.portal_type in ['Image', 'News Item']"
                     tal:omit-tag="not:thumbnail"


### PR DESCRIPTION
This needs to be addressed in the 1.3 series as well (Plone 4.x) /cc @chervol 

I created a tag 1.3.3 for that:
- https://github.com/davilima6/quintagroup.slidertemplates/releases/tag/1.3.3
- https://github.com/davilima6/quintagroup.slidertemplates/tree/improve_carousel_img_res_p4
- https://github.com/davilima6/quintagroup.slidertemplates/commit/67408b1ea55f2aade7f19367cee01db8232c81c7
